### PR TITLE
Update rules.yaml

### DIFF
--- a/rules.yaml
+++ b/rules.yaml
@@ -17,17 +17,17 @@ rules:
       field: description
       function: truthy
   request-description-is-mandatory:
-    description: Requests must have a description.
+    description: All requests must have a description.
     given: $..request
     severity: error
     then:
       field: description
       function: truthy
   folder-description-is-mandatory:
-    description: Folders must have a description.
+    description: All folders should have a description.
     message: "{{error}}"
     given: $
-    severity: error
+    severity: warn
     then:
       function: "folderDescription"
   request-url-is-mandatory:
@@ -38,20 +38,20 @@ rules:
       field: url
       function: truthy
   request-have-response-2XX-or-3XX:
-    description: Requests must have at least a response with code 2XX or 3XX.
+    description: All requests have at least a 2XX or 3XX example.
     given: $..item[*]
     severity: error
     then:
       function: request2XXor3XXResponse
   all-responses-have-status-code:
-    description: All the responses must have a status code.
+    description: All responses must have a status code.
     given: $..response[*]
     severity: error
     then:
       field: code
       function: truthy
   http-should-not-be-used:
-    description: HTTP should not be used
+    description: HTTP should not be used.
     message: "HTTP should not be used: {{value}}"
     given: $..url.raw
     severity: warn
@@ -60,19 +60,19 @@ rules:
       functionOptions:
         notMatch: "/^http:/i"
   delete-responses-should-have-200-or-204-code:
-    description: DELETE responses should have a 200 or 204 status code
+    description: DELETE responses must have a 200 or 204 status code.
     given: $..response[*]
     severity: error
     then:
       function: deleteResponse200or204
   path-variables-require-404-response:
-    description: Requests with path variables require a 404 response
+    description: Requests with path variables require a 404 response.
     given: $..item[*]
     severity: error
     then:
       function: pathVariablesRequire404Response
   examples-should-be-json-format:
-    description: Response bodies should be in JSON
+    description: Response bodies should be in JSON.
     message: "JSON should be used in examples: {{value}}"
     given: $..response[*]._postman_previewlanguage
     severity: warn
@@ -81,35 +81,35 @@ rules:
       functionOptions:
         match: "/^json/i"
   request-name-should-not-end-in-Copy:
-    description: Request names should not end in " Copy"
+    description: Request names should not end in "Copy".
     message: "{{error}}"
     given: $..item[*]
     severity: warn
     then:
       function: requestNameShouldNotEndInCopy
   query-parameters-require-description:
-    description: All the request query parameters must have a description.
+    description: All request query parameters must have a description.
     given: $..request.url.query[*]
     severity: error
     then:
       field: description
       function: truthy
   path-parameters-require-description:
-    description: All the request path parameters must have a description.
+    description: All request path parameters must have a description.
     given: $..request.url.variable[*]
     severity: error
     then:
       field: description
       function: truthy
   patch-requests-require-body:
-    description: All the patch requests require a body.
+    description: All PATCH requests require a request body.
     message: "{{error}}"
     given: $..request
     severity: error
     then:
       function: patchRequestShouldHaveBody
   authenticated-requests-require-401-response:
-    description: All the authenticated requests require a 401 response.
+    description: All authenticated requests require a 401 response.
     message: "{{error}}"
     given: $..item[*]
     severity: error


### PR DESCRIPTION
This updates the description to match what is in the README. It also updates the `folder-description-is-mandatory` from `error` type to `warn` status. This is because folders can be fairly self-explanatory in their names and shouldn't necessarily fail a lint because of a missing description.

@davidespihernandez Let me know if this change to the folder rule is OK (and if we should rename it from `folder-description-is-mandatory` to `folder-description-missing` or something.